### PR TITLE
Update bound IP to be configurable via Capybara.server_host

### DIFF
--- a/lib/capybara-puma.rb
+++ b/lib/capybara-puma.rb
@@ -5,7 +5,7 @@ module CapybaraPuma
   def self.activate
     Capybara.server do |app, port|
       Puma::Server.new(app).tap do |s|
-        s.add_tcp_listener '0.0.0.0', port
+        s.add_tcp_listener Capybara.server_host, port
       end.run.join
     end
   end


### PR DESCRIPTION
For some of my tests, I want a VM to be able to connect to my capybara host, thus it will be connecting on a different IP address (not 127.0.0.1). Changing the address to 0.0.0.0 makes the server listen to all local IPv4 locations.
